### PR TITLE
support swagger

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -52,6 +52,12 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <!-- Swagger UI dependencies -->
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-ui</artifactId>
+      <version>1.7.0</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Purpose
This PR is to add [spring doc openapi support](https://springdoc.org/v1/#getting-started) for this sample to make it integrated with swagger UI and API doc.

We add such support because we want to make this sample compatible with the [powerapps labs](https://github.com/microsoft/PowerPlatformAdvocates/tree/main/Workshops/JavaAndPowerApps/Lab1), which requires the swagger UI, e.g., https://github.com/microsoft/PowerPlatformAdvocates/blob/main/Workshops/JavaAndPowerApps/Lab2/README.md

The swagger UI will be available via links composed of ${application-public-endpoint}/swagger-ui.html

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
Follow the [README](https://github.com/Azure-Samples/ASA-Samples-Web-Application#quickstart) to run the sample
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
After it has been successfully running on ASA, copy the application endpoint from the terminal output, and add the suffix of `/swagger-ui.html` then go to that page in the browser.
```
![image](https://github.com/Azure-Samples/ASA-Samples-Web-Application/assets/63028776/a721be65-14e9-4f28-93cf-9948afd9b6e7)
![image](https://github.com/Azure-Samples/ASA-Samples-Web-Application/assets/63028776/edc868fa-9a2b-4c2e-a118-2b37a8694d28)

