### PR TITLE
add consumption plan as the default option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ azd init --template Azure-Samples/ASA-Samples-Web-Application
 azd up
 ```
 
+The template uses ASA consumption plan by default. If you want to switch to `Standard` plan, you can use the following command, then run `azd up`.
+
+```bash
+azd env set PLAN standard
+```
+
 ### Application Architecture
 
 This application utilizes the following Azure resources:

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ azd init --template Azure-Samples/ASA-Samples-Web-Application
 azd up
 ```
 
-The template uses [ASA consumption](https://learn.microsoft.com/azure/spring-apps/overview#standard-consumption-and-dedicated-plan) plan by default. If you want to switch to `Standard` plan, you can use the following command before running `azd up`.
+The template uses Azure Spring Apps [Standard consumption and dedicated plan](https://learn.microsoft.com/azure/spring-apps/overview#standard-consumption-and-dedicated-plan) by default. If you want to switch to `Standard` plan, you can use the following command before running `azd up`.
 
 ```bash
 azd env set PLAN standard
 ```
 
-If you have already provisioned the resources with the consumption plan and want to try the Standard plan, you need to run `azd down` first to delete the resources, and then run the above command and `azd up` again to provision and deploy.
+If you have already provisioned the resources with the Standard consumption and dedicated plan and want to try the Standard plan, you need to run `azd down` first to delete the resources, and then run the above command and `azd up` again to provision and deploy.
 
 ### Application Architecture
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ azd init --template Azure-Samples/ASA-Samples-Web-Application
 azd up
 ```
 
-The template uses ASA consumption plan by default. If you want to switch to `Standard` plan, you can use the following command, then run `azd up`.
+The template uses [ASA consumption](https://learn.microsoft.com/azure/spring-apps/overview#standard-consumption-and-dedicated-plan) plan by default. If you want to switch to `Standard` plan, you can use the following command before running `azd up`.
 
 ```bash
 azd env set PLAN standard
 ```
+
+If you have already provisioned the resources with the consumption plan and want to try the Standard plan, you need to run `azd down` first to delete the resources, and then run the above command and `azd up` again to provision and deploy.
 
 ### Application Architecture
 

--- a/infra/abbreviations.json
+++ b/infra/abbreviations.json
@@ -4,6 +4,7 @@
   "appConfigurationConfigurationStores": "appcs-",
   "appManagedEnvironments": "cae-",
   "appContainerApps": "ca-",
+  "appContainerAppsManagedEnvironment": "env-",
   "authorizationPolicyDefinitions": "policy-",
   "automationAutomationAccounts": "aa-",
   "blueprintBlueprints": "bp-",

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -13,10 +13,10 @@ param location string
 param relativePath string
 
 @allowed([
-  'Consumption'
-  'Standard'
+  'consumption'
+  'standard'
 ])
-param plan string
+param plan string = 'consumption'
 
 @secure()
 @description('PSQL Server administrator password')
@@ -64,7 +64,7 @@ module postgresql 'modules/postgresql/flexibleserver.bicep' = {
   }
 }
 
-module springAppsConsumption 'modules/springapps/springappsConsumption.bicep' = if (plan == 'Consumption') {
+module springAppsConsumption 'modules/springapps/springappsConsumption.bicep' = if (plan == 'consumption') {
   name: '${deployment().name}--asaconsumption'
   scope: resourceGroup(rg.name)
   params: {
@@ -80,7 +80,7 @@ module springAppsConsumption 'modules/springapps/springappsConsumption.bicep' = 
   }
 }
 
-module springAppsStandard 'modules/springapps/springappsStandard.bicep' = if (plan == 'Standard') {
+module springAppsStandard 'modules/springapps/springappsStandard.bicep' = if (plan == 'standard') {
   name: '${deployment().name}--asastandard'
   scope: resourceGroup(rg.name)
   params: {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -12,16 +12,23 @@ param location string
 @description('Relative Path of ASA Jar')
 param relativePath string
 
+@allowed([
+  'Consumption'
+  'Standard'
+])
+param plan string
+
 @secure()
 @description('PSQL Server administrator password')
-param psqlAdminPassword string
+param psqlAdminPassword string = 'SuperAdminPassword1!'
 
 @secure()
 @description('Application user password')
-param psqlUserPassword string
+param psqlUserPassword string = 'SuperUserPassword1!'
 
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+var asaManagedEnvironmentName = '${abbrs.appContainerAppsManagedEnvironment}${resourceToken}'
 var asaInstanceName = '${abbrs.springApps}${resourceToken}'
 var appName = 'simple-todo-web'
 var psqlServerName = '${abbrs.postgresServer}${resourceToken}'
@@ -57,13 +64,29 @@ module postgresql 'modules/postgresql/flexibleserver.bicep' = {
   }
 }
 
-module springApps 'modules/springapps/springapps.bicep' = {
-  name: '${deployment().name}--asa'
+module springAppsConsumption 'modules/springapps/springappsConsumption.bicep' = if (plan == 'Consumption') {
+  name: '${deployment().name}--asaconsumption'
   scope: resourceGroup(rg.name)
   params: {
     location: location
 	appName: appName
-	tags: union(tags, { 'azd-service-name': appName })
+	tags: tags
+	asaManagedEnvironmentName: asaManagedEnvironmentName
+	asaInstanceName: asaInstanceName
+	relativePath: relativePath
+	databaseUsername: psqlUserName
+	databasePassword: psqlUserPassword
+	datasourceUrl: datasourceJdbcUrl
+  }
+}
+
+module springAppsStandard 'modules/springapps/springappsStandard.bicep' = if (plan == 'Standard') {
+  name: '${deployment().name}--asastandard'
+  scope: resourceGroup(rg.name)
+  params: {
+    location: location
+	appName: appName
+	tags: tags
 	asaInstanceName: asaInstanceName
 	relativePath: relativePath
 	databaseUsername: psqlUserName

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -10,6 +10,9 @@
     },
     "relativePath": {
       "value": "${SERVICE_SIMPLE_TODO_WEB_RELATIVE_PATH=<default>}"
+    },
+    "plan": {
+      "value": "${PLAN=consumption}"
     }
   }
 }

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -8,12 +8,6 @@
     "location": {
       "value": "${AZURE_LOCATION}"
     },
-    "psqlAdminPassword": {
-      "value": "$(secretOrRandomPassword ${AZURE_KEY_VAULT_NAME} psqlAdminPassword)"
-    },
-    "psqlUserPassword": {
-      "value": "$(secretOrRandomPassword ${AZURE_KEY_VAULT_NAME} psqlUserPassword)"
-    },
     "relativePath": {
       "value": "${SERVICE_SIMPLE_TODO_WEB_RELATIVE_PATH=<default>}"
     }

--- a/infra/modules/postgresql/flexibleserver.bicep
+++ b/infra/modules/postgresql/flexibleserver.bicep
@@ -7,7 +7,7 @@ param psqlUserName string
 param psqlAdminPassword string
 @secure()
 param psqlUserPassword string
-param databaseName string = 'todo'
+param databaseName string
 param version string = '14'
 
 // Latest official version 2022-12-01 does not have Bicep types available

--- a/infra/modules/springapps/springappsConsumption.bicep
+++ b/infra/modules/springapps/springappsConsumption.bicep
@@ -1,0 +1,72 @@
+param location string = resourceGroup().location
+param asaManagedEnvironmentName string
+param asaInstanceName string
+param appName string
+param tags object = {}
+param relativePath string
+param databaseUsername string
+@secure()
+param databasePassword string
+param datasourceUrl string
+
+resource asaManagedEnvironment 'Microsoft.App/managedEnvironments@2022-11-01-preview' = {
+  name: asaManagedEnvironmentName
+  location: location
+  tags: tags
+  properties: {
+	workloadProfiles: [
+	  {
+	    name: 'Consumption'
+		workloadProfileType: 'Consumption'
+	  }
+    ]
+  }
+}
+
+resource asaInstance 'Microsoft.AppPlatform/Spring@2023-03-01-preview' = {
+  name: asaInstanceName
+  location: location
+  tags: union(tags, { 'azd-service-name': appName })
+  sku: {
+    name: 'S0'
+	tier: 'StandardGen2'
+  }
+  properties: {
+	managedEnvironmentId: asaManagedEnvironment.id
+  }
+}
+
+resource asaApp 'Microsoft.AppPlatform/Spring/apps@2023-03-01-preview' = {
+  name: appName
+  location: location
+  parent: asaInstance
+  properties: {
+    public: true
+  }
+}
+
+resource asaDeployment 'Microsoft.AppPlatform/Spring/apps/deployments@2023-03-01-preview' = {
+  name: 'default'
+  parent: asaApp
+  properties: {
+    source: {
+      type: 'Jar'
+      relativePath: relativePath
+      runtimeVersion: 'Java_17'
+    }
+    deploymentSettings: {
+      resourceRequests: {
+        cpu: '1'
+        memory: '2Gi'
+      }
+      environmentVariables: {
+		SPRING_DATASOURCE_URL: datasourceUrl
+		SPRING_DATASOURCE_USERNAME: databaseUsername
+		SPRING_DATASOURCE_PASSWORD: databasePassword
+	  }
+    }
+  }
+}
+
+output name string = asaApp.name
+output uri string = 'https://${asaApp.properties.url}'

--- a/infra/modules/springapps/springappsStandard.bicep
+++ b/infra/modules/springapps/springappsStandard.bicep
@@ -11,11 +11,11 @@ param datasourceUrl string
 resource asaInstance 'Microsoft.AppPlatform/Spring@2022-12-01' = {
   name: asaInstanceName
   location: location
-  tags: tags
+  tags: union(tags, { 'azd-service-name': appName })
   sku: {
-      name: 'B0'
-      tier: 'Basic'
-    }
+    name: 'S0'
+    tier: 'Standard'
+  }
 }
 
 resource asaApp 'Microsoft.AppPlatform/Spring/apps@2022-12-01' = {

--- a/web/src/main/resources/application.yml
+++ b/web/src/main/resources/application.yml
@@ -6,8 +6,7 @@ spring:
     serialization: 
       write-dates-as-timestamps: false
   jpa:
-    generate-ddl: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
 


### PR DESCRIPTION
This is pr is to make the AZD template support both ASA consumption plan and standard plan, and the default option will be the consumption plan.

To test it, you can run:
```
mkdir ASA-Samples-Web-Application
cd ASA-Samples-Web-Application
azd auth login
azd config set alpha.springapp on
azd init --template https://github.com/yiliuTo/ASA-Samples-Web-Application/ -b support-con
azd up
```

The template by default uses consumption plan, and if users want to use standard, they can set `azd env set PLAN standard` then run `azd up`. If users have already provisioned the resources with the consumption plan and want to try the Standard plan, they need to run `azd down` first to delete the resources, and then run `azd env set PLAN standard` and `azd up` again to provision and deploy.
