### PR TITLE
Fix netty err

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,22 +53,8 @@
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.1.0</version>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.1</version>
-        </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <configuration>
-          <tagNameFormat>v@{project.version}</tagNameFormat>
-          <autoVersionSubmodules>true</autoVersionSubmodules>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 
   <scm>


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* remove `maven-release-plugin` to avoid netty err:
```log
java.lang.NoClassDefFoundError: io/netty/channel/AbstractChannel$AbstractUnsafe$7
    at io.netty.channel.AbstractChannel$AbstractUnsafe.deregister (AbstractChannel.java:804)
    at io.netty.channel.AbstractChannel$AbstractUnsafe.fireChannelInactiveAndDeregister (AbstractChannel.java:764)
    at io.netty.channel.AbstractChannel$AbstractUnsafe.close (AbstractChannel.java:747)
    at io.netty.channel.AbstractChannel$AbstractUnsafe.close (AbstractChannel.java:620)
    at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.closeOnRead (AbstractNioByteChannel.java:105)
    at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.handleReadException (AbstractNioByteChannel.java:130)
    at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read (AbstractNioByteChannel.java:177)
    at io.netty.channel.nio.NioEventLoop.processSelectedKey (NioEventLoop.java:788)
    at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized (NioEventLoop.java:724)
    at io.netty.channel.nio.NioEventLoop.processSelectedKeys (NioEventLoop.java:650)
    at io.netty.channel.nio.NioEventLoop.run (NioEventLoop.java:562)
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run (SingleThreadEventExecutor.java:997)
    at io.netty.util.internal.ThreadExecutorMap$2.run (ThreadExecutorMap.java:74)
    at io.netty.util.concurrent.FastThreadLocalRunnable.run (FastThreadLocalRunnable.java:30)
    at java.lang.Thread.run (Thread.java:833)
Caused by: java.lang.ClassNotFoundException: io.netty.channel.AbstractChannel$AbstractUnsafe$7
    at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass (SelfFirstStrategy.java:50)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass (ClassRealm.java:271)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass (ClassRealm.java:247)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass (ClassRealm.java:239)
    at io.netty.channel.AbstractChannel$AbstractUnsafe.deregister (AbstractChannel.java:804)
    at io.netty.channel.AbstractChannel$AbstractUnsafe.fireChannelInactiveAndDeregister (AbstractChannel.java:764)
    at io.netty.channel.AbstractChannel$AbstractUnsafe.close (AbstractChannel.java:747)
    at io.netty.channel.AbstractChannel$AbstractUnsafe.close (AbstractChannel.java:620)
    at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.closeOnRead (AbstractNioByteChannel.java:105)
    at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.handleReadException (AbstractNioByteChannel.java:130)
    at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read (AbstractNioByteChannel.java:177)
    at io.netty.channel.nio.NioEventLoop.processSelectedKey (NioEventLoop.java:788)
    at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized (NioEventLoop.java:724)
    at io.netty.channel.nio.NioEventLoop.processSelectedKeys (NioEventLoop.java:650)
    at io.netty.channel.nio.NioEventLoop.run (NioEventLoop.java:562)
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run (SingleThreadEventExecutor.java:997)
    at io.netty.util.internal.ThreadExecutorMap$2.run (ThreadExecutorMap.java:74)
    at io.netty.util.concurrent.FastThreadLocalRunnable.run (FastThreadLocalRunnable.java:30)
    at java.lang.Thread.run (Thread.java:833)
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```